### PR TITLE
Fixed multiple-messages per packet parsing failure

### DIFF
--- a/lib/collectd/protocol.js
+++ b/lib/collectd/protocol.js
@@ -205,11 +205,19 @@ function interpret_results(results){
                 break;
             case TYPE_VALUES:
                 v.data = obj[1];
-                val_objects.push(v);
+                val_objects.push(clone(v));
                 break;
         };
     });
     return [val_objects, notifications];
+}
+
+function clone(obj) {
+    var new_obj = {};
+    Object.keys(obj).forEach(function(key) {
+        new_obj[key] = obj[key];
+    });
+    return new_obj;
 }
 
 exports.collectd_parse = function decode_network_packet(buf){


### PR DESCRIPTION
Hi,

It seems that if there's multiple values in a single UDP packet the way that you were processing the messages in the interpret function was causing things to get overwritten as it worked through them.

My patch just clones the values each time it pushes them on to the result list, and consequently fixes the issue.
